### PR TITLE
Fixed if len(data)==0 and transient issue for streaming menu as well

### DIFF
--- a/src/plotterViewModel.py
+++ b/src/plotterViewModel.py
@@ -196,7 +196,7 @@ class PlotterViewModel(EventClass):
         else:
             data = self._get_real_data()
 
-        if not self.streams or self.current_stream_index >= len(self.streams):
+        if len(data) == 0:
             return {
                 'has_data': False,
                 'data': [],


### PR DESCRIPTION
I changed the if statement to if len(data)==0 so now real data should run. I also deleted the menu.transient line in plotterView.py to fix the streaming menu's Windows compatibility issue. In both Windows and Mac, upon right click of the drop-down display (not the options in the dropdown) a menu with ability to Rename, Delete, and Close Menu should appear. If someone with Windows could please test out the feature it would be extremely helpful. It should look something like attached image and you should be able to delete and rename streams. Also the menu should not go away until user presses close menu.

<img width="284" height="157" alt="Screenshot 2025-11-07 at 7 27 38 PM" src="https://github.com/user-attachments/assets/e19fbd24-14c1-4ba9-a303-4a0189ee9262" />

